### PR TITLE
Showing a video player to a user on the web app

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -48,3 +48,9 @@
     height: auto;
     cursor: pointer;
 }
+
+@media screen and (min-width: 480px) {
+    .video-wrapper .embed-responsive {
+        min-width: 80vw;
+    }
+}


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5148

## Description
Showing a video player to a user on the web app

## Screenshots/screencasts
![5148-_online-video-cutter com_](https://user-images.githubusercontent.com/53430352/69959024-ce1db400-150e-11ea-998b-9270eb7fac90.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
This issue occurs only in the single-column layout. As I understand because this layout doesn't have a given width on large devices so I've added a `min-width:80vw;` for showing a video player.